### PR TITLE
Unsubscribe from the remote storage

### DIFF
--- a/SubstrateSdk.podspec
+++ b/SubstrateSdk.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SubstrateSdk'
-  s.version          = '1.1.0'
+  s.version          = '1.2.0'
   s.summary          = 'Utility library that implements clients specific logic to interact with substrate based networks'
 
   s.homepage         = 'https://github.com/nova-wallet/substrate-sdk-ios'

--- a/SubstrateSdk/Classes/Network/RPCMethod.swift
+++ b/SubstrateSdk/Classes/Network/RPCMethod.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum RPCMethod {
     public static let storageSubscribe = "state_subscribeStorage"
+    public static let storageUnsubscribe = "state_unsubscribeStorage"
     public static let chain = "system_chain"
     public static let getStorage = "state_getStorage"
     public static let getStorageKeysPaged = "state_getKeysPaged"

--- a/SubstrateSdk/Classes/Network/WebSocketEngine.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine.swift
@@ -457,12 +457,15 @@ extension WebSocketEngine {
         pendingSubscriptionResponses[remoteId] = nil
 
         do {
-            _ = try callMethod(
-                RPCMethod.storageUnsubscribe,
-                params: [remoteId]
+            let request = try prepareRequest(
+                method: RPCMethod.storageUnsubscribe,
+                params: [remoteId],
+                options: JSONRPCOptions()
             ) { [weak self] (result: (Result<Bool, Error>)) in
                 self?.provideUnsubscriptionResult(result, remoteId: remoteId)
             }
+
+            updateConnectionForRequest(request)
         } catch {
             logger?.error("(\(chainName):\(selectedURL)) Failed to create unsubscription request: \(error)")
         }


### PR DESCRIPTION
When a client cancels the subscription request one should also check that this subscription is actually established and send unsubscribe request