### PR TITLE
Add raw extrinsic payload as signing payload format

### DIFF
--- a/SubstrateSdk.podspec
+++ b/SubstrateSdk.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SubstrateSdk'
-  s.version          = '1.3.0'
+  s.version          = '1.4.0'
   s.summary          = 'Utility library that implements clients specific logic to interact with substrate based networks'
 
   s.homepage         = 'https://github.com/nova-wallet/substrate-sdk-ios'

--- a/SubstrateSdk/Classes/Extrinsic/ExtrinsicBuilder.swift
+++ b/SubstrateSdk/Classes/Extrinsic/ExtrinsicBuilder.swift
@@ -169,6 +169,14 @@ public class ExtrinsicBuilder {
         encodingBy encoder: DynamicScaleEncoding,
         using metadata: RuntimeMetadataProtocol
     ) throws -> Data {
+        let payload = try prepareNotHashedSignaturePayload(encodingBy: encoder, using: metadata)
+        return try ExtrinsicSignatureConverter.convertExtrinsicPayloadToRegular(payload)
+    }
+
+    private func prepareNotHashedSignaturePayload(
+        encodingBy encoder: DynamicScaleEncoding,
+        using metadata: RuntimeMetadataProtocol
+    ) throws -> Data {
         let call = try prepareExtrinsicCall(for: metadata)
         try encoder.append(json: call, type: GenericType.call.name)
 
@@ -177,7 +185,7 @@ public class ExtrinsicBuilder {
 
         let payload = try encoder.encode()
 
-        return try ExtrinsicSignatureConverter.convertExtrinsicPayloadToRegular(payload)
+        return payload
     }
 
     private func prepareSignaturePayload(
@@ -189,6 +197,8 @@ public class ExtrinsicBuilder {
             return try prepareRegularSignaturePayload(encodingBy: encoder, using: metadata)
         case .paritySigner:
             return try prepareParitySignerSignaturePayload(encodingBy: encoder, using: metadata)
+        case .extrinsicPayload:
+            return try prepareNotHashedSignaturePayload(encodingBy: encoder, using: metadata)
         }
     }
 }

--- a/SubstrateSdk/Classes/Extrinsic/ExtrinsicSignaturePayloadFormat.swift
+++ b/SubstrateSdk/Classes/Extrinsic/ExtrinsicSignaturePayloadFormat.swift
@@ -3,4 +3,5 @@ import Foundation
 public enum ExtrinsicSignaturePayloadFormat {
     case regular
     case paritySigner
+    case extrinsicPayload
 }


### PR DESCRIPTION
To support extrinsic signing by Ledger one needs to pass raw extrinsic payload (not hashed). To support this option new signing payload format (extrinsicPayload) is introduced.