### PR TITLE
Add fallback to alternative batch name

### DIFF
--- a/SubstrateSdk.podspec
+++ b/SubstrateSdk.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SubstrateSdk'
-  s.version          = '1.4.1'
+  s.version          = '1.5.0'
   s.summary          = 'Utility library that implements clients specific logic to interact with substrate based networks'
 
   s.homepage         = 'https://github.com/nova-wallet/substrate-sdk-ios'

--- a/SubstrateSdk/Classes/Extrinsic/ExtrinsicBuilder.swift
+++ b/SubstrateSdk/Classes/Extrinsic/ExtrinsicBuilder.swift
@@ -92,9 +92,19 @@ public class ExtrinsicBuilder {
             return calls[0]
         }
 
-        let callName = shouldUseAtomicBatch ? KnowRuntimeModule.Utitlity.batchAll : KnowRuntimeModule.Utitlity.batch
+        let callName: String
 
-        let call = RuntimeCall(moduleName: KnowRuntimeModule.Utitlity.name,
+        if shouldUseAtomicBatch {
+            if metadata.getCall(from: KnowRuntimeModule.Utility.name, with: KnowRuntimeModule.Utility.batchAll) != nil {
+                callName = KnowRuntimeModule.Utility.batchAll
+            } else {
+                callName = KnowRuntimeModule.Utility.batchAtomic
+            }
+        } else {
+            callName = KnowRuntimeModule.Utility.batch
+        }
+
+        let call = RuntimeCall(moduleName: KnowRuntimeModule.Utility.name,
                                callName: callName,
                                args: BatchArgs(calls: calls))
 

--- a/SubstrateSdk/Classes/Runtime/Metadata/KnownRuntimeModule.swift
+++ b/SubstrateSdk/Classes/Runtime/Metadata/KnownRuntimeModule.swift
@@ -1,9 +1,10 @@
 import Foundation
 
 public struct KnowRuntimeModule {
-    public struct Utitlity {
+    public struct Utility {
         public static let name = "Utility"
         public static let batch = "batch"
         public static let batchAll = "batch_all"
+        public static let batchAtomic = "batch_atomic"
     }
 }

--- a/Tests/ExtrinsicBuilder/ExtrinsicBuilderTests.swift
+++ b/Tests/ExtrinsicBuilder/ExtrinsicBuilderTests.swift
@@ -26,8 +26,8 @@ class ExtrinsicBuilderTests: XCTestCase {
             }
 
             let expectedJsonCalls = try calls.toScaleCompatibleJSON()
-            let expectedCall = try RuntimeCall(moduleName: KnowRuntimeModule.Utitlity.name,
-                                               callName: KnowRuntimeModule.Utitlity.batch,
+            let expectedCall = try RuntimeCall(moduleName: KnowRuntimeModule.Utility.name,
+                                               callName: KnowRuntimeModule.Utility.batch,
                                                args: BatchArgs(calls: expectedJsonCalls.arrayValue!))
                                 .toScaleCompatibleJSON()
 
@@ -64,8 +64,8 @@ class ExtrinsicBuilderTests: XCTestCase {
             }
 
             let expectedJsonCalls = try calls.toScaleCompatibleJSON()
-            let expectedCall = try RuntimeCall(moduleName: KnowRuntimeModule.Utitlity.name,
-                                               callName: KnowRuntimeModule.Utitlity.batchAll,
+            let expectedCall = try RuntimeCall(moduleName: KnowRuntimeModule.Utility.name,
+                                               callName: KnowRuntimeModule.Utility.batchAll,
                                                args: BatchArgs(calls: expectedJsonCalls.arrayValue!))
                                 .toScaleCompatibleJSON()
 


### PR DESCRIPTION
Some utility pallets (for example, for Polymesh network) uses batch_atomic name instead of batch_all