### PR TITLE
Support chaotic batch responses

### DIFF
--- a/SubstrateSdk.podspec
+++ b/SubstrateSdk.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SubstrateSdk'
-  s.version          = '1.8.0'
+  s.version          = '1.9.0'
   s.summary          = 'Utility library that implements clients specific logic to interact with substrate based networks'
 
   s.homepage         = 'https://github.com/nova-wallet/substrate-sdk-ios'

--- a/SubstrateSdk/Classes/Network/JSONRPCEngine.swift
+++ b/SubstrateSdk/Classes/Network/JSONRPCEngine.swift
@@ -103,7 +103,7 @@ class JSONRPCBatchHandler: JSONRPCResponseHandling {
 
             receivedResponses[identifier] = createResult(from: response)
         } catch {
-
+            receivedResponses[identifier] = .failure(error)
         }
 
         notifyCallbackIfReady()
@@ -111,6 +111,8 @@ class JSONRPCBatchHandler: JSONRPCResponseHandling {
 
     func handle(error: Error, for identifier: UInt16) {
         receivedResponses[identifier] = .failure(error)
+
+        notifyCallbackIfReady()
     }
 }
 

--- a/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
@@ -141,7 +141,6 @@ extension WebSocketEngine: WebSocketDelegate {
             responseWebsocketPong(for: data)
         default:
             logger?.warning("(\(chainName):\(selectedURL)) Ping data received but not connected")
-            break
         }
     }
 }

--- a/SubstrateSdk/Classes/Network/WebSocketEngine.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine.swift
@@ -352,7 +352,7 @@ extension WebSocketEngine {
             subscription.remoteId = nil
         }
 
-        let subscriptionRequests: [JSONRPCRequest] = activeSubscriptions.enumerated().compactMap {
+        let subscriptionRequests: [JSONRPCRequest] = activeSubscriptions.enumerated().map {
             JSONRPCRequest(
                 requestId: .single($1.requestId),
                 data: $1.requestData,
@@ -731,11 +731,7 @@ extension WebSocketEngine {
             pendingRequests = []
 
             let requestError = error ?? JSONRPCEngineError.unknownError
-            requests.forEach { request in
-                request.requestId.itemIds.forEach { identifier in
-                    request.responseHandler?.handle(error: requestError, for: identifier)
-                }
-            }
+            notify(requests: requests, error: requestError)
         }
     }
 


### PR DESCRIPTION
Batch response can be received not in the order in which were sent. Moreover requests inside batches can come as a separate single response.

To address the issue, requests in batches are now stored in groups only in pending state. When batch is sent it is converted to in progress single requests which shares common handler to gather responses. Common batch handler triggers completion block only when it received response for each batch request.