### PR TITLE
Custom logic for switching nodes

### DIFF
--- a/SubstrateSdk.podspec
+++ b/SubstrateSdk.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SubstrateSdk'
-  s.version          = '1.10.0'
+  s.version          = '1.11.0'
   s.summary          = 'Utility library that implements clients specific logic to interact with substrate based networks'
 
   s.homepage         = 'https://github.com/nova-wallet/substrate-sdk-ios'

--- a/SubstrateSdk.podspec
+++ b/SubstrateSdk.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SubstrateSdk'
-  s.version          = '1.11.0'
+  s.version          = '1.12.0'
   s.summary          = 'Utility library that implements clients specific logic to interact with substrate based networks'
 
   s.homepage         = 'https://github.com/nova-wallet/substrate-sdk-ios'

--- a/SubstrateSdk/Classes/Network/HTTPEngine+Protocol.swift
+++ b/SubstrateSdk/Classes/Network/HTTPEngine+Protocol.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+extension HTTPEngine: JSONRPCEngine {
+    public func subscribe<P, T>(
+        _ method: String,
+        params: P?,
+        unsubscribeMethod: String,
+        updateClosure: @escaping (T) -> Void,
+        failureClosure: @escaping (Error, Bool) -> Void
+    ) throws -> UInt16 where P: Encodable, T: Decodable {
+        throw JSONRPCEngineError.unsupportedMethod
+    }
+
+    public func callMethod<P, T>(
+        _ method: String,
+        params: P?,
+        options: JSONRPCOptions,
+        completion closure: ((Result<T, Error>) -> Void)?
+    ) throws -> UInt16 where P: Encodable, T: Decodable {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        let requestId = generateRequestId()
+        let request = try requestFactory.prepareRequest(
+            method: method,
+            params: params,
+            options: options,
+            completion: closure,
+            idType: .existing(requestId)
+        )
+
+        guard let url = nextUnusedUrl(for: request.requestId) else {
+            throw JSONRPCEngineError.unknownError
+        }
+
+        send(
+            request: request,
+            url: url,
+            timeout: timeout,
+            encoder: requestFactory.jsonEncoder,
+            decoder: requestFactory.jsonDecoder
+        )
+
+        return requestId
+    }
+
+    public func cancelForIdentifiers(_ identifiers: [UInt16]) {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        for identifier in identifiers {
+            if let operation = unbindOperation(for: identifier) {
+                operation.cancel()
+            }
+        }
+    }
+
+    public func submitBatch(
+        for batchId: JSONRPCBatchId,
+        options: JSONRPCOptions,
+        completion closure: (([Result<JSON, Error>]) -> Void)?
+    ) throws -> [UInt16] {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        guard let batchItems = partialBatches[batchId] else {
+            throw JSONRPCEngineError.emptyResult
+        }
+
+        clearPartialBatchStorage(for: batchId)
+
+        let request = try requestFactory.prepareBatchRequest(
+            batchId: batchId,
+            from: batchItems,
+            options: options,
+            completion: closure
+        )
+
+        guard let url = nextUnusedUrl(for: request.requestId) else {
+            throw JSONRPCEngineError.unknownError
+        }
+
+        send(
+            request: request,
+            url: url,
+            timeout: timeout,
+            encoder: requestFactory.jsonEncoder,
+            decoder: requestFactory.jsonDecoder
+        )
+
+        return request.requestId.itemIds
+    }
+
+    public func addBatchCallMethod<P>(_ method: String, params: P?, batchId: JSONRPCBatchId) throws where P: Encodable {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        let requestId = generateRequestId()
+        let batchItem = try requestFactory.prepareBatchRequestItem(
+            method: method,
+            params: params,
+            idType: .existing(requestId)
+        )
+
+        storeBatchItem(batchItem, for: batchId)
+    }
+
+    public func clearBatch(for batchId: JSONRPCBatchId) {
+        mutex.lock()
+
+        defer {
+            mutex.unlock()
+        }
+
+        clearPartialBatchStorage(for: batchId)
+    }
+}

--- a/SubstrateSdk/Classes/Network/HTTPEngine.swift
+++ b/SubstrateSdk/Classes/Network/HTTPEngine.swift
@@ -1,0 +1,282 @@
+import Foundation
+import RobinHood
+
+public final class HTTPEngine {
+    struct Response {
+        let basicInfo: JSONRPCBasicData
+        let originalData: Data
+    }
+
+    public let urls: [URL]
+
+    public let name: String?
+    public let logger: SDKLoggerProtocol?
+    public let completionQueue: DispatchQueue
+    public let operationQueue: OperationQueue
+    public let timeout: TimeInterval
+    public let customNodeSwitcher: JSONRPCNodeSwitching?
+
+    public var chainName: String { name ?? "unknown" }
+
+    internal let requestFactory: JSONRPCRequestFactory
+
+    internal let mutex = NSLock()
+
+    private(set) var inProgressRequests: [UInt16: JSONRPCRequestId] = [:]
+    private(set) var requestIdMapping: [JSONRPCRequestId: Operation] = [:]
+    private(set) var requestAttempts: [JSONRPCRequestId: Set<URL>] = [:]
+    private(set) var partialBatches: [String: [JSONRPCBatchRequestItem]] = [:]
+
+    public init(
+        urls: [URL],
+        operationQueue: OperationQueue,
+        version: String = "2.0",
+        customNodeSwitcher: JSONRPCNodeSwitching? = nil,
+        timeout: TimeInterval = 60,
+        completionQueue: DispatchQueue? = nil,
+        name: String? = nil,
+        logger: SDKLoggerProtocol? = nil
+    ) {
+        self.urls = urls
+        self.requestFactory = JSONRPCRequestFactory(version: version)
+        self.completionQueue = completionQueue ?? JSONRPCEngineShared.processingQueue
+        self.customNodeSwitcher = customNodeSwitcher
+        self.operationQueue = operationQueue
+        self.timeout = timeout
+        self.name = name
+        self.logger = logger
+    }
+
+    func storeBatchItem(_ item: JSONRPCBatchRequestItem, for batchId: JSONRPCBatchId) {
+        var items = partialBatches[batchId] ?? []
+        items.append(item)
+
+        partialBatches[batchId] = items
+    }
+
+    func clearPartialBatchStorage(for batchId: JSONRPCBatchId) {
+        partialBatches[batchId] = nil
+    }
+
+    func bindRequest(request: JSONRPCRequest, operation: Operation) {
+        requestIdMapping[request.requestId] = operation
+
+        for identifier in request.requestId.itemIds {
+            inProgressRequests[identifier] = request.requestId
+        }
+    }
+
+    func unbindRequest(request: JSONRPCRequest, operation: Operation) -> Bool {
+        guard requestIdMapping[request.requestId] === operation else {
+            return false
+        }
+
+        requestIdMapping[request.requestId] = nil
+
+        for identifier in request.requestId.itemIds {
+            inProgressRequests[identifier] = nil
+        }
+
+        return true
+    }
+
+    func unbindOperation(for identifier: UInt16) -> Operation? {
+        guard let requestId = inProgressRequests[identifier] else {
+            return nil
+        }
+
+        let operation = requestIdMapping[requestId]
+
+        inProgressRequests[identifier] = nil
+        requestIdMapping[requestId] = nil
+
+        return operation
+    }
+
+    func generateRequestId() -> UInt16 {
+        let pendingItems = inProgressRequests.keys
+        let partialBatches = partialBatches.values.flatMap { batch in
+            batch.map { $0.requestId }
+        }
+
+        let existingIds: Set<UInt16> = Set(pendingItems + partialBatches)
+
+        return requestFactory.generateRequestId(skipping: existingIds)
+    }
+
+    func nextUnusedUrl(for requestId: JSONRPCRequestId) -> URL? {
+        let usedUrls = requestAttempts[requestId] ?? Set()
+        return urls.first { !usedUrls.contains($0) }
+    }
+
+    func hasNotUsedUrls(for requestId: JSONRPCRequestId) -> Bool {
+        nextUnusedUrl(for: requestId) != nil
+    }
+
+    func storeUsedUrl(_ url: URL, for requestId: JSONRPCRequestId) {
+        var usedUrls = requestAttempts[requestId] ?? Set()
+        usedUrls.insert(url)
+
+        requestAttempts[requestId] = usedUrls
+    }
+
+    func clearAttempts(for requestId: JSONRPCRequestId) {
+        requestAttempts[requestId] = nil
+    }
+
+    func resendRequest(_ request: JSONRPCRequest) {
+        guard let nextUrl = nextUnusedUrl(for: request.requestId) else {
+            logger?.debug("(\(chainName)) no url to retry request: \(request)")
+            return
+        }
+
+        logger?.debug("(\(chainName):\(nextUrl)) retrying request: \(request)")
+
+        send(
+            request: request,
+            url: nextUrl,
+            timeout: timeout,
+            encoder: requestFactory.jsonEncoder,
+            decoder: requestFactory.jsonDecoder
+        )
+    }
+
+    func shouldRetryRequest(_ request: JSONRPCRequest, result: Result<[Response], Error>?) -> Bool {
+        guard request.options.resendOnReconnect else {
+            return false
+        }
+
+        switch result {
+        case let .success(responses):
+            guard let customNodeSwitcher = customNodeSwitcher else {
+                return false
+            }
+
+            let hasErrorToRetry = responses.contains { response in
+                guard let error = response.basicInfo.error, let identifier = response.basicInfo.identifier else {
+                    return false
+                }
+
+                return customNodeSwitcher.shouldInterceptAndSwitchNode(for: error, identifier: identifier)
+            }
+
+            return hasErrorToRetry && hasNotUsedUrls(for: request.requestId)
+        case .failure:
+            return hasNotUsedUrls(for: request.requestId)
+        case .none:
+            return false
+        }
+    }
+
+    func createRequestFactory(request: JSONRPCRequest, url: URL, timeout: TimeInterval) -> BlockNetworkRequestFactory {
+        BlockNetworkRequestFactory {
+            var urlRequest = URLRequest(url: url)
+            urlRequest.httpMethod = HttpMethod.post.rawValue
+
+            urlRequest.httpBody = request.data
+            urlRequest.setValue(HttpContentType.json.rawValue, forHTTPHeaderField: HttpHeaderKey.contentType.rawValue)
+            urlRequest.timeoutInterval = timeout
+
+            return urlRequest
+        }
+    }
+
+    func createResultFactory(
+        for request: JSONRPCRequest,
+        encoder: JSONEncoder,
+        decoder: JSONDecoder
+    ) -> AnyNetworkResultFactory<[Response]> {
+        AnyNetworkResultFactory { data in
+            switch request.requestId {
+            case .batch:
+                let responseList = try decoder.decode([JSON].self, from: data)
+
+                return try responseList.map { jsonResponse in
+                    let basicInfo = try jsonResponse.map(to: JSONRPCBasicData.self)
+                    let originalData = try encoder.encode(jsonResponse)
+
+                    return .init(basicInfo: basicInfo, originalData: originalData)
+                }
+            case .single:
+                let basicInfo = try decoder.decode(JSONRPCBasicData.self, from: data)
+                let response = Response(basicInfo: basicInfo, originalData: data)
+
+                return [response]
+            }
+        }
+    }
+
+    func notifyResponseHandler(_ responseHandler: JSONRPCResponseHandling, response: Response) {
+        if let identifier = response.basicInfo.identifier {
+            if let error = response.basicInfo.error {
+                responseHandler.handle(error: error, for: identifier)
+            } else {
+                responseHandler.handle(data: response.originalData, for: identifier)
+            }
+        }
+    }
+
+    func notifyResponseHandler(_ responseHandler: JSONRPCResponseHandling, error: Error, requestId: JSONRPCRequestId) {
+        for identifier in requestId.itemIds {
+            responseHandler.handle(error: error, for: identifier)
+        }
+    }
+
+    func processResult(of operation: NetworkOperation<[Response]>, for request: JSONRPCRequest, url: URL) {
+        guard unbindRequest(request: request, operation: operation) else {
+            return
+        }
+
+        guard !shouldRetryRequest(request, result: operation.result) else {
+            resendRequest(request)
+            return
+        }
+
+        clearAttempts(for: request.requestId)
+
+        guard let responseHandler = request.responseHandler else {
+            return
+        }
+
+        logger?.debug("(\(chainName):\(url)) processing result: \(String(describing: operation.result))")
+
+        switch operation.result {
+        case let .success(responses):
+            for response in responses {
+                notifyResponseHandler(responseHandler, response: response)
+            }
+        case let .failure(error):
+            notifyResponseHandler(responseHandler, error: error, requestId: request.requestId)
+        case .none:
+            let error = BaseOperationError.unexpectedDependentResult
+            notifyResponseHandler(responseHandler, error: error, requestId: request.requestId)
+        }
+    }
+
+    func send(request: JSONRPCRequest, url: URL, timeout: TimeInterval, encoder: JSONEncoder, decoder: JSONDecoder) {
+        let requestFactory = createRequestFactory(request: request, url: url, timeout: timeout)
+
+        let resultFactory = createResultFactory(for: request, encoder: encoder, decoder: decoder)
+
+        let operation = NetworkOperation(requestFactory: requestFactory, resultFactory: resultFactory)
+
+        operation.completionBlock = {
+            self.completionQueue.async {
+                self.mutex.lock()
+
+                defer {
+                    self.mutex.unlock()
+                }
+
+                self.processResult(of: operation, for: request, url: url)
+            }
+        }
+
+        bindRequest(request: request, operation: operation)
+        storeUsedUrl(url, for: request.requestId)
+
+        logger?.debug("(\(chainName):\(url)) sending request: \(request)")
+
+        operationQueue.addOperation(operation)
+    }
+}

--- a/SubstrateSdk/Classes/Network/JSONRPCEngine.swift
+++ b/SubstrateSdk/Classes/Network/JSONRPCEngine.swift
@@ -5,6 +5,7 @@ public enum JSONRPCEngineError: Error {
     case remoteCancelled
     case clientCancelled
     case unknownError
+    case unsupportedMethod
 }
 
 public protocol JSONRPCResponseHandling {

--- a/SubstrateSdk/Classes/Network/JSONRPCEngineShared.swift
+++ b/SubstrateSdk/Classes/Network/JSONRPCEngineShared.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum JSONRPCEngineShared {
+    public static let processingQueue = DispatchQueue(label: "com.nova.ws.processing")
+}

--- a/SubstrateSdk/Classes/Network/JSONRPCNodeSwitching.swift
+++ b/SubstrateSdk/Classes/Network/JSONRPCNodeSwitching.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-public protocol WebSocketNodeSwitching {
+public protocol JSONRPCNodeSwitching {
     func shouldInterceptAndSwitchNode(for error: JSONRPCError, identifier: UInt16) -> Bool
 }
 
-public final class JSONRRPCodeNodeSwitcher: WebSocketNodeSwitching {
+public final class JSONRRPCodeNodeSwitcher: JSONRPCNodeSwitching {
     let codes: Set<Int>
 
     public init(codes: Set<Int>) {

--- a/SubstrateSdk/Classes/Network/JSONRPCRequestFactory.swift
+++ b/SubstrateSdk/Classes/Network/JSONRPCRequestFactory.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+class JSONRPCRequestFactory {
+    enum IdType {
+        case existing(UInt16)
+        case generate(skipping: Set<UInt16>)
+    }
+
+    lazy var jsonEncoder = JSONEncoder()
+    lazy var jsonDecoder = JSONDecoder()
+
+    let version: String
+
+    init(version: String) {
+        self.version = version
+    }
+
+    func prepareRequestData<P: Encodable>(
+        method: String,
+        requestId: UInt16,
+        params: P?
+    ) throws -> Data {
+        if let params = params {
+            let info = JSONRPCInfo(
+                identifier: requestId,
+                jsonrpc: version,
+                method: method,
+                params: params
+            )
+
+            return try jsonEncoder.encode(info)
+        } else {
+            let info = JSONRPCInfo(
+                identifier: requestId,
+                jsonrpc: version,
+                method: method,
+                params: [String]()
+            )
+
+            return try jsonEncoder.encode(info)
+        }
+    }
+
+    func prepareBatchRequestItem<P: Encodable>(
+        method: String,
+        params: P?,
+        idType: IdType
+    ) throws -> JSONRPCBatchRequestItem {
+        let requestId = getRequestId(for: idType)
+
+        let data = try prepareRequestData(method: method, requestId: requestId, params: params)
+
+        return JSONRPCBatchRequestItem(requestId: requestId, data: data)
+    }
+
+    func prepareBatchRequest(
+        batchId: JSONRPCBatchId,
+        from batchItems: [JSONRPCBatchRequestItem],
+        options: JSONRPCOptions,
+        completion closure: (([Result<JSON, Error>]) -> Void)?
+    ) throws -> JSONRPCRequest {
+        let jsonList = try batchItems.map { try jsonDecoder.decode(JSON.self, from: $0.data) }
+        let itemIds = batchItems.map { $0.requestId }
+
+        let data = try jsonEncoder.encode(JSON.arrayValue(jsonList))
+
+        let handler: JSONRPCBatchHandler?
+
+        if let closure = closure {
+            handler = JSONRPCBatchHandler(itemIds: itemIds, completionClosure: closure)
+        } else {
+            handler = nil
+        }
+
+        return JSONRPCRequest(
+            requestId: .batch(batchId: batchId, itemIds: itemIds),
+            data: data,
+            options: options,
+            responseHandler: handler
+        )
+    }
+
+    func prepareRequest<P: Encodable, T: Decodable>(
+        method: String,
+        params: P?,
+        options: JSONRPCOptions,
+        completion closure: ((Result<T, Error>) -> Void)?,
+        idType: IdType
+    ) throws -> JSONRPCRequest {
+        let requestId = getRequestId(for: idType)
+        let data: Data = try prepareRequestData(method: method, requestId: requestId, params: params)
+
+        let handler: JSONRPCResponseHandling?
+
+        if let completionClosure = closure {
+            handler = JSONRPCResponseHandler(completionClosure: completionClosure)
+        } else {
+            handler = nil
+        }
+
+        let request = JSONRPCRequest(
+            requestId: .single(requestId),
+            data: data,
+            options: options,
+            responseHandler: handler
+        )
+
+        return request
+    }
+
+    func getRequestId(for type: IdType) -> UInt16 {
+        switch type {
+        case let .existing(identifier):
+            return identifier
+        case let .generate(skippingSet):
+            return generateRequestId(skipping: skippingSet)
+        }
+    }
+
+    func generateRequestId(skipping existingIds: Set<UInt16>) -> UInt16 {
+        var targetId = (1 ... UInt16.max).randomElement() ?? 1
+
+        while existingIds.contains(targetId) {
+            targetId += 1
+        }
+
+        return targetId
+    }
+}

--- a/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine+Delegate.swift
@@ -71,7 +71,7 @@ extension WebSocketEngine: WebSocketDelegate {
 
             notify(
                 requests: cancelledRequests,
-                error: JSONRPCEngineError.clientCancelled
+                error: JSONRPCEngineError.unknownError
             )
         case .connecting:
             forceConnectionReset()

--- a/SubstrateSdk/Classes/Network/WebSocketEngine+Protocol.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine+Protocol.swift
@@ -12,7 +12,13 @@ extension WebSocketEngine: JSONRPCEngine {
             mutex.unlock()
         }
 
-        let batchItem = try prepareBatchRequestItem(method: method, params: params)
+        let requestId = generateRequestId()
+        let batchItem = try requestFactory.prepareBatchRequestItem(
+            method: method,
+            params: params,
+            idType: .existing(requestId)
+        )
+
         storeBatchItem(batchItem, for: batchId)
     }
 
@@ -33,7 +39,7 @@ extension WebSocketEngine: JSONRPCEngine {
 
         clearPartialBatchStorage(for: batchId)
 
-        let request = try prepareBatchRequest(
+        let request = try requestFactory.prepareBatchRequest(
             batchId: batchId,
             from: batchItems,
             options: options,

--- a/SubstrateSdk/Classes/Network/WebSocketEngine.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketEngine.swift
@@ -763,6 +763,8 @@ extension WebSocketEngine {
 
         let reconnectionAttempt = switchNode()
         startConnecting(reconnectionAttempt)
+
+        notify(requests: cancelledRequests, error: JSONRPCEngineError.unknownError)
     }
 
     func switchNode() -> Int {

--- a/SubstrateSdk/Classes/Network/WebSocketNodeSwitching.swift
+++ b/SubstrateSdk/Classes/Network/WebSocketNodeSwitching.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public protocol WebSocketNodeSwitching {
+    func shouldInterceptAndSwitchNode(for error: JSONRPCError, identifier: UInt16) -> Bool
+}
+
+public final class JSONRRPCodeNodeSwitcher: WebSocketNodeSwitching {
+    let codes: Set<Int>
+
+    public init(codes: Set<Int>) {
+        self.codes = codes
+    }
+
+    public func shouldInterceptAndSwitchNode(for error: JSONRPCError, identifier: UInt16) -> Bool {
+        codes.contains(error.code)
+    }
+}


### PR DESCRIPTION
Currently node switching happens only if there is an error on web socket protocol level. However there might be error on application level when node switching also helpful - for example, api rate limit.

This PR introduces concept of node switching interceptor that checks if the JSONRPCError requires node switching and seamlessly (all the pending requests with retry flag and subscriptions are resent automatically) performs node switching.