### PR TITLE
Improve round robin logic

### DIFF
--- a/SubstrateSdk.podspec
+++ b/SubstrateSdk.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SubstrateSdk'
-  s.version          = '1.12.0'
+  s.version          = '1.13.0'
   s.summary          = 'Utility library that implements clients specific logic to interact with substrate based networks'
 
   s.homepage         = 'https://github.com/nova-wallet/substrate-sdk-ios'

--- a/SubstrateSdk/Classes/Network/HTTPEngine+Protocol.swift
+++ b/SubstrateSdk/Classes/Network/HTTPEngine+Protocol.swift
@@ -32,13 +32,9 @@ extension HTTPEngine: JSONRPCEngine {
             idType: .existing(requestId)
         )
 
-        guard let url = nextUnusedUrl(for: request.requestId) else {
-            throw JSONRPCEngineError.unknownError
-        }
-
         send(
             request: request,
-            url: url,
+            url: selectedURL,
             timeout: timeout,
             encoder: requestFactory.jsonEncoder,
             decoder: requestFactory.jsonDecoder
@@ -55,6 +51,8 @@ extension HTTPEngine: JSONRPCEngine {
         }
 
         for identifier in identifiers {
+            unbindResendAttempts(for: identifier)
+
             if let operation = unbindOperation(for: identifier) {
                 operation.cancel()
             }
@@ -85,13 +83,9 @@ extension HTTPEngine: JSONRPCEngine {
             completion: closure
         )
 
-        guard let url = nextUnusedUrl(for: request.requestId) else {
-            throw JSONRPCEngineError.unknownError
-        }
-
         send(
             request: request,
-            url: url,
+            url: selectedURL,
             timeout: timeout,
             encoder: requestFactory.jsonEncoder,
             decoder: requestFactory.jsonDecoder


### PR DESCRIPTION
New logic tries to receive data from the endpoint no more than ```maxAttemptsPerNode``` and then switches to new url if available using round robin approach